### PR TITLE
Authenticate using an OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The script will by default look for a file named `config.ini` located in the sam
 
 To quickly get started, rename `config.ini.sample` to `config.ini`, and edit the fields to match your login info and repository info. If you want to use a different credentials for the source and target repositories, please see [_Configuration: Enterprise Accounts and Advanced Login Options_](http://www.iqandreas.com/github-issues-import/configuration/#enterprise). Store the config file in the same folder as the `gh-issues-import.py` script, or store it in a different folder, using the `--config <file>` option to specify which config file to load in.
 
-**Warning:** The password is stored in plain-text, so avoid storing the config file in a public repository. To avoid this, you can instead pass the username and/or password as arguments by using the `-u <username>` and `-p <password>` flags respectively. If the username or password is not passed in from either of these locations, the user will be prompted for them when the script runs.
+**Warning:** The password is stored in plain-text, so avoid storing the config file in a public repository. To avoid this, you can instead pass the username and/or password as arguments by using the `-u <username>` and `-p <password>` flags respectively. Also there is an option to pass a [personal access token](https://github.com/blog/1509-personal-api-tokens) as `-o <token>` argument instead of the password. If the username or password/token is not passed in from either of these locations, the user will be prompted for them when the script runs.
  
 Run the script with the following command to import all open issues into the repository defined in the config:
 

--- a/config-enterprise.ini.sample
+++ b/config-enterprise.ini.sample
@@ -6,12 +6,14 @@ server = github.com
 repository = OctoCat/Hello-World
 username = octocat@github.com
 password = plaintext_pa$$w0rd
+token = api_access_token
 
 [target]
 server = octodog.org
 repository = OctoDog/Hello-World
 username = admin@octodog.org
 password = plaintext_pass\/\/ord
+token = api_access_token
 
 [format] # These can be adjusted based on your group's region and language.
 

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -4,6 +4,7 @@
 [login]
 username = OctoDog
 password = plaintext_pa$$w0rd
+token = api_access_token
 
 [source]
 repository = OctoCat/Hello-World


### PR DESCRIPTION
A github enterprise installation could have the password authentication disabled. That's why token authentication alternative needs to be supported.

There was already a try with #24 that didn't quite worked. @hanxue, @asmeurer, @JensTimmerman would you please give it another chance?
