### PR TITLE
Add comment label milestone paging

### DIFF
--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -200,7 +200,7 @@ def send_request_paginate(which, url):
 	while should_run:
 		current_url = url + ("page=%s" % page_num)
 		current_result = send_request(which, current_url)
-		if len(current_result) > 0:
+		if current_result:
 			retval.extend(current_result)
 			page_num += 1
 		else:
@@ -245,7 +245,7 @@ def get_milestones(which):
 	return send_request(which, "milestones?state=open")
 
 def get_labels(which):
-	return send_request(which, "labels")
+	return send_request_paginate(which, "labels")
 	
 def get_issue_by_id(which, issue_id):
 	return send_request(which, "issues/%d" % issue_id)

--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -187,6 +187,26 @@ def format_comment(template_data):
 	template = config.get('format', 'comment_template', fallback=default_template)
 	return format_from_template(template, template_data)
 
+def send_request_paginate(which, url):
+	if "?" not in url:
+		url += "?"
+	else:
+		url += "&"
+
+	retval = []
+	page_num = 1
+	should_run = True
+
+	while should_run:
+		current_url = url + ("page=%s" % page_num)
+		current_result = send_request(which, current_url)
+		if len(current_result) > 0:
+			retval.extend(current_result)
+			page_num += 1
+		else:
+			should_run = False
+	return retval
+
 def send_request(which, url, post_data=None):
 
 	if post_data is not None:
@@ -252,7 +272,7 @@ def get_issues_by_state(which, state):
 
 def get_comments_on_issue(which, issue):
 	if issue['comments'] != 0:
-		return send_request(which, "issues/%s/comments" % issue['number'])
+		return send_request_paginate(which, "issues/%s/comments" % issue['number'])
 	else :
 		return []
 

--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -260,7 +260,7 @@ def get_issues_by_id(which, issue_ids):
 
 # Allowed values for state are 'open' and 'closed'
 def get_issues_by_state(which, state):
-        return send_request_paginate(which, "issues?state=%s&direction=asc" % state)
+	return send_request_paginate(which, "issues?state=%s&direction=asc" % state)
 
 def get_comments_on_issue(which, issue):
 	if issue['comments'] != 0:

--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -242,7 +242,7 @@ def send_request(which, url, post_data=None):
 	return json.loads(json_data.decode("utf-8"))
 
 def get_milestones(which):
-	return send_request(which, "milestones?state=open")
+	return send_request_paginate(which, "milestones?state=open")
 
 def get_labels(which):
 	return send_request_paginate(which, "labels")

--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -260,15 +260,7 @@ def get_issues_by_id(which, issue_ids):
 
 # Allowed values for state are 'open' and 'closed'
 def get_issues_by_state(which, state):
-	issues = []
-	page = 1
-	while True:
-		new_issues = send_request(which, "issues?state=%s&direction=asc&page=%d" % (state, page))
-		if not new_issues:
-			break
-		issues.extend(new_issues)
-		page += 1
-	return issues
+        return send_request_paginate(which, "issues?state=%s&direction=asc" % state)
 
 def get_comments_on_issue(which, issue):
 	if issue['comments'] != 0:


### PR DESCRIPTION
Fixes both #55 and #62.  Added a basic handler (`send_request_paginate`) for results which need paging, and used this handler for getting labels, comments, and milestones.  Reimplemented `get_issues_by_state` (which performed such handling) in terms of the new basic handler.