### PR TITLE
Skip cert validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/*
 __pycache__/*
 *.py~
+.env
 
 # This is to prevent you from making the idiotic mistake of committing and uploading your
 # config file that includes your password in plaintext into a publicly available repo!


### PR DESCRIPTION
Implemented the skip SSL certificate validation to help migrations from invalid HTTPS instances. This is common when the company uses a reverse proxy that adds the same official certificate but for a private network access. I already saw this happening twice(different companies, big ones).