### PR TITLE
Ignore pull requests

### DIFF
--- a/gh-issues-import.py
+++ b/gh-issues-import.py
@@ -23,7 +23,7 @@ class state:
 	IMPORTING            = "importing"
 	IMPORT_COMPLETE      = "import-complete"
 	COMPLETE             = "script-complete"
-	
+
 state.current = state.INITIALIZING
 
 http_error_messages = {}
@@ -33,32 +33,32 @@ http_error_messages[404] = "ERROR: Unable to find the specified repository.\nDou
 
 
 def init_config():
-	
+
 	config.add_section('login')
 	config.add_section('source')
 	config.add_section('target')
 	config.add_section('format')
 	config.add_section('settings')
-	
+
 	arg_parser = argparse.ArgumentParser(description="Import issues from one GitHub repository into another.")
-	
+
 	config_group = arg_parser.add_mutually_exclusive_group(required=False)
 	config_group.add_argument('--config', help="The location of the config file (either absolute, or relative to the current working directory). Defaults to `config.ini` found in the same folder as this script.")
 	config_group.add_argument('--no-config', dest='no_config',  action='store_true', help="No config file will be used, and the default `config.ini` will be ignored. Instead, all settings are either passed as arguments, or (where possible) requested from the user as a prompt.")
-	
+
 	arg_parser.add_argument('-u', '--username', help="The username of the account that will create the new issues. The username will not be stored anywhere if passed in as an argument.")
 	arg_parser.add_argument('-p', '--password', help="The password (in plaintext) of the account that will create the new issues. The password will not be stored anywhere if passed in as an argument.")
 	arg_parser.add_argument('-s', '--source', help="The source repository which the issues should be copied from. Should be in the format `user/repository`.")
 	arg_parser.add_argument('-t', '--target', help="The destination repository which the issues should be copied to. Should be in the format `user/repository`.")
-	
-	arg_parser.add_argument('--ignore-comments',  dest='ignore_comments',  action='store_true', help="Do not import comments in the issue.")		
+
+	arg_parser.add_argument('--ignore-comments',  dest='ignore_comments',  action='store_true', help="Do not import comments in the issue.")
 	arg_parser.add_argument('--ignore-milestone', dest='ignore_milestone', action='store_true', help="Do not import the milestone attached to the issue.")
 	arg_parser.add_argument('--ignore-labels',    dest='ignore_labels',    action='store_true', help="Do not import labels attached to the issue.")
-	
+
 	arg_parser.add_argument('--issue-template', help="Specify a template file for use with issues.")
 	arg_parser.add_argument('--comment-template', help="Specify a template file for use with comments.")
 	arg_parser.add_argument('--pull-request-template', help="Specify a template file for use with pull requests.")
-		
+
 	include_group = arg_parser.add_mutually_exclusive_group(required=True)
 	include_group.add_argument("--all", dest='import_all', action='store_true', help="Import all issues, regardless of state.")
 	include_group.add_argument("--open", dest='import_open', action='store_true', help="Import only open issues.")
@@ -66,7 +66,7 @@ def init_config():
 	include_group.add_argument("-i", "--issues", type=int, nargs='+', help="The list of issues to import.");
 
 	args = arg_parser.parse_args()
-	
+
 	def load_config_file(config_file_name):
 		try:
 			config_file = open(config_file_name)
@@ -74,7 +74,7 @@ def init_config():
 			return True
 		except (FileNotFoundError, IOError):
 			return False
-	
+
 	if args.no_config:
 		print("Ignoring default config file. You may be prompted for some missing settings.")
 	elif args.config:
@@ -91,49 +91,49 @@ def init_config():
 			print("Default config file not found in '%s'" % config_file_name)
 			print("You may be prompted for some missing settings.")
 
-	
+
 	if args.username: config.set('login', 'username', args.username)
 	if args.password: config.set('login', 'password', args.password)
-	
+
 	if args.source: config.set('source', 'repository', args.source)
 	if args.target: config.set('target', 'repository', args.target)
-	
+
 	if args.issue_template: config.set('format', 'issue_template', args.issue_template)
 	if args.comment_template: config.set('format', 'comment_template', args.comment_template)
 	if args.pull_request_template: config.set('format', 'pull_request_template', args.pull_request_template)
-	
+
 	config.set('settings', 'import-comments',  str(not args.ignore_comments))
 	config.set('settings', 'import-milestone', str(not args.ignore_milestone))
 	config.set('settings', 'import-labels',    str(not args.ignore_labels))
-	
+
 	config.set('settings', 'import-open-issues',   str(args.import_all or args.import_open));
 	config.set('settings', 'import-closed-issues', str(args.import_all or args.import_closed));
-	
-	
+
+
 	# Make sure no required config values are missing
 	if not config.has_option('source', 'repository') :
 		sys.exit("ERROR: There is no source repository specified either in the config file, or as an argument.")
 	if not config.has_option('target', 'repository') :
 		sys.exit("ERROR: There is no target repository specified either in the config file, or as an argument.")
-	
-	
+
+
 	def get_server_for(which):
 		# Default to 'github.com' if no server is specified
 		if (not config.has_option(which, 'server')):
 			config.set(which, 'server', "github.com")
-		
+
 		# if SOURCE server is not github.com, then assume ENTERPRISE github (yourdomain.com/api/v3...)
 		if (config.get(which, 'server') == "github.com") :
 			api_url = "https://api.github.com"
 		else:
 			api_url = "https://%s/api/v3" % config.get(which, 'server')
-		
+
 		config.set(which, 'url', "%s/repos/%s" % (api_url, config.get(which, 'repository')))
-	
+
 	get_server_for('source')
 	get_server_for('target')
-	
-	
+
+
 	# Prompt for username/password if none is provided in either the config or an argument
 	def get_credentials_for(which):
 		if not config.has_option(which, 'username'):
@@ -144,7 +144,7 @@ def init_config():
 			else:
 				query_str = "Enter your username for '%s' at '%s': " % (config.get(which, 'repository'), config.get(which, 'server'))
 				config.set(which, 'username', query.username(query_str))
-		
+
 		if not config.has_option(which, 'password'):
 			if config.has_option('login', 'password'):
 				config.set(which, 'password', config.get('login', 'password'))
@@ -153,10 +153,10 @@ def init_config():
 			else:
 				query_str = "Enter your password for '%s' at '%s': " % (config.get(which, 'repository'), config.get(which, 'server'))
 				config.set(which, 'password', query.password(query_str))
-	
+
 	get_credentials_for('source')
 	get_credentials_for('target')
-	
+
 	# Everything is here! Continue on our merry way...
 	return args.issues or []
 
@@ -165,7 +165,7 @@ def format_date(datestring):
 	date = datetime.datetime.strptime(datestring, "%Y-%m-%dT%H:%M:%SZ")
 	date_format = config.get('format', 'date', fallback='%A %b %d, %Y at %H:%M GMT', raw=True);
 	return date.strftime(date_format)
-	
+
 def format_from_template(template_filename, template_data):
 	from string import Template
 	template_file = open(template_filename, 'r')
@@ -187,30 +187,33 @@ def format_comment(template_data):
 	template = config.get('format', 'comment_template', fallback=default_template)
 	return format_from_template(template, template_data)
 
-def send_request(which, url, post_data=None):
+def send_request(which, url, post_data=None, method=None):
 
 	if post_data is not None:
 		post_data = json.dumps(post_data).encode("utf-8")
-	
+
 	full_url = "%s/%s" % (config.get(which, 'url'), url)
-	req = urllib.request.Request(full_url, post_data)
-	
+	if method:
+		req = urllib.request.Request(full_url, post_data, method=method)
+	else:
+		req = urllib.request.Request(full_url, post_data, method=method)
+
 	username = config.get(which, 'username')
 	password = config.get(which, 'password')
 	req.add_header("Authorization", b"Basic " + base64.urlsafe_b64encode(username.encode("utf-8") + b":" + password.encode("utf-8")))
-	
+
 	req.add_header("Content-Type", "application/json")
 	req.add_header("Accept", "application/json")
 	req.add_header("User-Agent", "IQAndreas/github-issues-import")
-	
+
 	try:
 		response = urllib.request.urlopen(req)
 		json_data = response.read()
 	except urllib.error.HTTPError as error:
-		
+
 		error_details = error.read();
 		error_details = json.loads(error_details.decode("utf-8"))
-		
+
 		if error.code in http_error_messages:
 			sys.exit(http_error_messages[error.code])
 		else:
@@ -229,7 +232,7 @@ def get_milestones(which):
 
 def get_labels(which):
 	return send_request(which, "labels")
-	
+
 def get_issue_by_id(which, issue_id):
 	return send_request(which, "issues/%d" % issue_id)
 
@@ -238,7 +241,7 @@ def get_issues_by_id(which, issue_ids):
 	issues = []
 	for issue_id in issue_ids:
 		issues.append(get_issue_by_id(which, int(issue_id)))
-	
+
 	return issues
 
 # Allowed values for state are 'open' and 'closed'
@@ -266,7 +269,7 @@ def import_milestone(source):
 		"description": source['description'],
 		"due_on": source['due_on']
 	}
-	
+
 	result_milestone = send_request('target', "milestones", source)
 	print("Successfully created milestone '%s'" % result_milestone['title'])
 	return result_milestone
@@ -276,7 +279,7 @@ def import_label(source):
 		"name": source['name'],
 		"color": source['color']
 	}
-	
+
 	result_label = send_request('target', "labels", source)
 	print("Successfully created label '%s'" % result_label['name'])
 	return result_label
@@ -300,6 +303,11 @@ def import_comments(comments, issue_number):
 
 	return result_comments
 
+def patch_issue(which, issue_number, issue_payload):
+	'''Edit an existing issue, see https://developer.github.com/v3/issues/#edit-an-issue'''
+	result = send_request(which, 'issues/{number}'.format(number=issue_number), issue_payload, method='PATCH')
+	return result
+
 # Will only import milestones and issues that are in use by the imported issues, and do not exist in the target repository
 def import_issues(issues):
 
@@ -318,8 +326,8 @@ def import_issues(issues):
 		return None
 
 	new_issues = []
-	open_issues = []
-	closed_issues = []
+	open_issue_ids = []
+	closed_issue_ids = []
 	num_new_comments = 0
 	new_milestones = []
 	new_labels = []
@@ -329,10 +337,13 @@ def import_issues(issues):
 		new_issue = {}
 		new_issue['title'] = issue['title']
 
+		# note: id will not be created remotely, used for local dereferencing
+		# note: id is not the same as number
+		new_issue['id'] = issue['id']
 		if issue['state'] == 'open':
-			open_issues.append(issue)
+			open_issue_ids.append(issue['id'])
 		elif issue['state'] == 'closed':
-			closed_issues.append(issue)
+			closed_issue_ids.append(issue['id'])
 
 		if config.getboolean('settings', 'import-comments') and 'comments' in issue and issue['comments'] != 0:
 			num_new_comments += int(issue['comments'])
@@ -378,8 +389,8 @@ def import_issues(issues):
 	state.current = state.IMPORT_CONFIRMATION
 
 	print("You are about to add to '" + config.get('target', 'repository') + "':")
-	print(" *", len(open_issues), "open issues")
-	print(" *", len(closed_issues), "closed issues")
+	print(" *", len(open_issue_ids), "open issues")
+	print(" *", len(closed_issue_ids), "closed issues")
 	print(" *", num_new_comments, "new comments")
 	print(" *", len(new_milestones), "new milestones")
 	print(" *", len(new_labels), "new labels")
@@ -412,6 +423,9 @@ def import_issues(issues):
 
 		result_issue = send_request('target', "issues", issue)
 		print("Successfully created issue '%s'" % result_issue['title'])
+		if issue['id'] in closed_issue_ids:
+			issue['state'] = 'closed'
+			patch_issue('target', result_issue['number'], issue)
 
 		if 'comments' in issue:
 			result_comments = import_comments(issue['comments'], result_issue['number'])


### PR DESCRIPTION
Add a command line option `--ignore-pull-requests` to avoid importing pull request issues.

Existing [command line arguments](http://www.iqandreas.com/github-issues-import/arguments/) allow for the following import options:
```
--ignore-comments     Do not import comments in the issue.
--ignore-milestone    Do not import the milestone attached to the issue.
--ignore-labels       Do not import labels attached to the issue.
```
This change set adds the following option. If this option is specified then pull request type issues are not imported.
```
--ignore-pull-requests   Do not import pull requests.
```